### PR TITLE
selinux: Fix BLN labeling

### DIFF
--- a/rootdir/init.carrier.rc
+++ b/rootdir/init.carrier.rc
@@ -57,4 +57,4 @@ on boot
     chown system system /sys/class/misc/backlightnotification/enabled
     chown system system /sys/class/misc/backlightnotification/blink_control
     chown system system /sys/class/misc/backlightnotification/notification_led
-    restorecon_recursive /sys/class/misc/backlightnotification
+    restorecon /sys/class/misc/backlightnotification/enabled


### PR DESCRIPTION
Using restorecon_recursive doesn't work anymore. Wonderful!

Change-Id: I2136ead1a40f5d513b73bad9b8b42bd5fabf5548